### PR TITLE
changed Kosovo country code

### DIFF
--- a/mrz/base/countries.py
+++ b/mrz/base/countries.py
@@ -276,7 +276,7 @@ english = {
     "European Union": "EUE",
     "United Nations Organization": "UNO",
     "United Nations Agency": "UNA",
-    "Kosovo": "UNK",
+    "Kosovo": "RKS",
     "African Development Bank": "XBA",
     "Afrexim": "XIM",
     "Caricom": "XCC",

--- a/mrz/base/countries.py
+++ b/mrz/base/countries.py
@@ -276,7 +276,8 @@ english = {
     "European Union": "EUE",
     "United Nations Organization": "UNO",
     "United Nations Agency": "UNA",
-    "Kosovo": "RKS",
+    "Kosovo UN": "UNK",  # ceased being issued in 2008
+    "Kosovo": "RKS",  # not ICAO-endorsed
     "African Development Bank": "XBA",
     "Afrexim": "XIM",
     "Caricom": "XCC",


### PR DESCRIPTION
- changed country code for Kosovo from UNK to RKS. As per [this link](https://en.wikipedia.org/wiki/Kosovan_passport) the `RKS` code is not an official ISO code, but it appears on identity documents of Kosovo