### PR TITLE
fix belgium card checker

### DIFF
--- a/mrz/special_cases/checker/id_card_belgium.py
+++ b/mrz/special_cases/checker/id_card_belgium.py
@@ -19,4 +19,6 @@ class TD1BELCodeChecker(TD1CodeChecker):
             doc_number_fin = self._optional_data.rstrip("<")
             self._document_number = self._document_number + "<" + doc_number_fin[:-1]
             self._document_number_hash = doc_number_fin[-1]
+        if not hash_is_ok(self._document_number, self._document_number_hash):
+            self._document_number = self._document_number.replace("<","")
         return self.report.add("document number hash", hash_is_ok(self._document_number, self._document_number_hash))


### PR DESCRIPTION
fixes #4 for Belgium id card from 2020, document number checker 
example : 
`IDBEL000590696<1015<<<<<<<<<<<
9401013F2710017BEL000101123453
SPECIMEN<<SPECIMEN<<<<<<<<<<<<`